### PR TITLE
Add usb mouse support

### DIFF
--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/AbstractMorseInput.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/AbstractMorseInput.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -38,8 +39,10 @@ import com.paddlesandbugs.dahdidahdit.base.LearningValue;
 public abstract class AbstractMorseInput {
 
     public static final String PREFS_KEY_KEY_CODE_LEFT = "key_code_left";
+    public static final String PREFS_KEY_IS_MOUSE_LEFT = "key_code_left_is_mouse";
 
     public static final String PREFS_KEY_KEY_CODE_RIGHT = "key_code_right";
+    public static final String PREFS_KEY_IS_MOUSE_RIGHT = "key_code_right_is_mouse";
 
     private final Activity context;
 
@@ -121,8 +124,10 @@ public abstract class AbstractMorseInput {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         final int keyCodeLeft = prefs.getInt(PREFS_KEY_KEY_CODE_LEFT, KeyEvent.KEYCODE_A);
         final int keyCodeRight = prefs.getInt(PREFS_KEY_KEY_CODE_RIGHT, KeyEvent.KEYCODE_B);
+        final boolean isMouseLeft = prefs.getBoolean(PREFS_KEY_IS_MOUSE_LEFT, false);
+        final boolean isMouseRight = prefs.getBoolean(PREFS_KEY_IS_MOUSE_RIGHT, false);
 
-        hwPaddle = new HardwarePaddle(keyer, keyCodeLeft, keyCodeRight);
+        hwPaddle = new HardwarePaddle(keyer, keyCodeLeft, keyCodeRight, isMouseLeft, isMouseRight);
         osPaddle = new OnScreenPaddle(context, keyer);
 
         wpm.setOnChangeListener(new LearningValue.OnChangeListener() {
@@ -179,6 +184,7 @@ public abstract class AbstractMorseInput {
     public void handleKey(KeyEvent event) {
         this.hwPaddle.handleKey(event);
     }
+    public void handleMouse(MotionEvent event) { this.hwPaddle.handleMouse(event); }
 
 
     private static class SpeedButtonClickListener implements View.OnClickListener {

--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/AbstractPaddleInputActivity.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/AbstractPaddleInputActivity.java
@@ -20,7 +20,9 @@ package com.paddlesandbugs.dahdidahdit.brasspound;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.InputDevice;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
 import androidx.annotation.NonNull;
 
@@ -106,6 +108,17 @@ public abstract class AbstractPaddleInputActivity extends AbstractNavigationActi
     public boolean dispatchKeyEvent(KeyEvent event) {
         morseInput.handleKey(event);
         return super.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if (event.getSource() != InputDevice.SOURCE_TOUCHSCREEN) {
+            morseInput.handleMouse(event); // otherwise taps on screen interfere; we only support EXTERNAL devices
+
+            return true;
+        }
+
+        return super.dispatchTouchEvent(event);
     }
 
     /**

--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/HardwareKeySensor.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/HardwareKeySensor.java
@@ -19,22 +19,27 @@
 package com.paddlesandbugs.dahdidahdit.brasspound;
 
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
 public class HardwareKeySensor {
 
     private final int keyCode;
     private final Keyer keyer;
     private final int key;
+    public final boolean isMouse;
 
 
-    public HardwareKeySensor(int keyCode, Keyer keyer, int key) {
+    public HardwareKeySensor(int keyCode, Keyer keyer, int key, boolean isMouse) {
         this.keyCode = keyCode;
         this.keyer = keyer;
         this.key = key;
+        this.isMouse = isMouse;
     }
 
 
     public void dispatchKeyEvent(KeyEvent e) {
+        if (isMouse) return;
+
         if (e.getKeyCode() == keyCode) {
             if (e.getRepeatCount() == 0) {
 
@@ -47,5 +52,12 @@ public class HardwareKeySensor {
                 }
             }
         }
+    }
+
+    public void dispatchTouchEvent(MotionEvent e) {
+        if (!isMouse) return;
+
+        if ((e.getButtonState() & keyCode) > 0) keyer.keyDown(key);
+        else keyer.keyUp(key);
     }
 }

--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/HardwarePaddle.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/brasspound/HardwarePaddle.java
@@ -19,6 +19,7 @@
 package com.paddlesandbugs.dahdidahdit.brasspound;
 
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
 public class HardwarePaddle {
 
@@ -28,9 +29,9 @@ public class HardwarePaddle {
 
     private boolean active = true;
 
-    public HardwarePaddle(Keyer keyer, int keyCodeLeft, int keyCodeRight) {
-        keySensorLeft = new HardwareKeySensor(keyCodeLeft, keyer, AbstractPaddleKeyer.KEY_LEFT);
-        keySensorRight = new HardwareKeySensor(keyCodeRight, keyer, AbstractPaddleKeyer.KEY_RIGHT);
+    public HardwarePaddle(Keyer keyer, int keyCodeLeft, int keyCodeRight, boolean isMouseLeft, boolean isMouseRight) {
+        keySensorLeft = new HardwareKeySensor(keyCodeLeft, keyer, AbstractPaddleKeyer.KEY_LEFT, isMouseLeft);
+        keySensorRight = new HardwareKeySensor(keyCodeRight, keyer, AbstractPaddleKeyer.KEY_RIGHT, isMouseRight);
     }
 
     public void setActive(boolean active) {
@@ -41,6 +42,13 @@ public class HardwarePaddle {
         if (active) {
             keySensorLeft.dispatchKeyEvent(event);
             keySensorRight.dispatchKeyEvent(event);
+        }
+    }
+
+    public void handleMouse(MotionEvent event) {
+        if (active) {
+            keySensorLeft.dispatchTouchEvent(event);
+            keySensorRight.dispatchTouchEvent(event);
         }
     }
 }

--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/settings/ButtonPreference.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/settings/ButtonPreference.java
@@ -19,7 +19,11 @@
 package com.paddlesandbugs.dahdidahdit.settings;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.AttributeSet;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -31,6 +35,8 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
 import com.paddlesandbugs.dahdidahdit.R;
+
+import java.util.ArrayList;
 
 public class ButtonPreference extends Preference {
 
@@ -46,19 +52,36 @@ public class ButtonPreference extends Preference {
         setWidgetLayoutResource(R.layout.button_preference);
     }
 
+    protected String getKeyCodeDisplayLabel(int keyCode, boolean isMouse) {
+        if (isMouse) {
+            ArrayList<String> buttons = new ArrayList<>();
 
+            if ((keyCode & MotionEvent.BUTTON_BACK) > 0) buttons.add("BUTTON_BACK");
+            if ((keyCode & MotionEvent.BUTTON_FORWARD) > 0) buttons.add("BUTTON_FORWARD");
+            if ((keyCode & MotionEvent.BUTTON_PRIMARY) > 0) buttons.add("BUTTON_PRIMARY");
+            if ((keyCode & MotionEvent.BUTTON_SECONDARY) > 0) buttons.add("BUTTON_SECONDARY");
+            if ((keyCode & MotionEvent.BUTTON_TERTIARY) > 0) buttons.add("BUTTON_TERTIARY");
+            if ((keyCode & MotionEvent.BUTTON_STYLUS_PRIMARY) > 0) buttons.add("BUTTON_STYLUS_PRIMARY");
+            if ((keyCode & MotionEvent.BUTTON_STYLUS_SECONDARY) > 0) buttons.add("BUTTON_STYLUS_SECONDARY");
 
+            return String.join(", ", buttons);
+        }
+
+        return KeyEvent.keyCodeToString(keyCode);
+    }
 
     @Override
     public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
 
         final String buttonKey = getKey();
+        final String isMouseKey = buttonKey + "_is_mouse";
         final CharSequence title = getTitle();
         final int keyCode = getSharedPreferences().getInt(buttonKey, 0);
+        final boolean isMouse = getSharedPreferences().getBoolean(isMouseKey, false);
 
         TextView textView = (TextView) holder.findViewById(R.id.keycodetextview);
-        textView.setText(Integer.toString(keyCode));
+        textView.setText(getKeyCodeDisplayLabel(keyCode, isMouse));
 
         Button button = (Button) holder.findViewById(R.id.button);
         button.setText(R.string.record_paddle_key_code);
@@ -68,16 +91,49 @@ public class ButtonPreference extends Preference {
             @Override
             public void onClick(View v) {
                 Context activity = getContext();
+                button.setText((R.string.recording_paddle_key_code));
                 if (activity instanceof SettingsActivity) {
                     ((SettingsActivity) activity).setKeyEventFunction(keyEvent -> {
                         final int keyCode = keyEvent.getKeyCode();
-                        getSharedPreferences().edit().putInt(buttonKey, keyCode).apply();
-                        textView.setText(Integer.toString(keyCode));
+
+                        SharedPreferences.Editor editor = getSharedPreferences().edit();
+                        editor.putInt(buttonKey, keyCode);
+                        editor.putBoolean(isMouseKey, false);
+                        editor.apply();
+
+                        textView.setText(getKeyCodeDisplayLabel(keyCode, false));
+
+                        stopRecording();
+                        return true;
+                    });
+
+                    ((SettingsActivity) activity).setMotionEventFunction(motionEvent -> {
+                        // only capture from external devices, no screen taps
+                        if (motionEvent.getSource() == InputDevice.SOURCE_TOUCHSCREEN) return false;
+
+                        final int buttonState = motionEvent.getButtonState();
+
+                        SharedPreferences.Editor editor = getSharedPreferences().edit();
+                        editor.putInt(buttonKey, buttonState);
+                        editor.putBoolean(isMouseKey, true);
+                        editor.apply();
+
+                        textView.setText(getKeyCodeDisplayLabel(buttonState, true));
+
+                        stopRecording();
                         return true;
                     });
 
                     Toast.makeText(activity, R.string.record_paddle_prompt, Toast.LENGTH_LONG).show();
                 }
+            }
+
+            public void stopRecording() {
+                button.setText(R.string.record_paddle_key_code);
+
+                Context activity = getContext();
+                ((SettingsActivity) activity).setMotionEventFunction(null);
+                ((SettingsActivity) activity).setKeyEventFunction(null);
             }
         });
 

--- a/app/src/main/java/com/paddlesandbugs/dahdidahdit/settings/SettingsActivity.java
+++ b/app/src/main/java/com/paddlesandbugs/dahdidahdit/settings/SettingsActivity.java
@@ -24,6 +24,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 
 import androidx.annotation.Keep;
 import androidx.appcompat.app.ActionBar;
@@ -66,6 +67,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     private SharedPreferences.OnSharedPreferenceChangeListener configChangedListener;
 
     private Function<KeyEvent, Boolean> keyEventFunction = null;
+    private Function<MotionEvent, Boolean> motionEventFunction = null;
 
 
     public static void callMe(Context context, String settingsPart) {
@@ -147,11 +149,13 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     //        }
     //    }
 
-
     public void setKeyEventFunction(Function<KeyEvent, Boolean> keyEventFunction) {
         this.keyEventFunction = keyEventFunction;
     }
 
+    public void setMotionEventFunction(Function<MotionEvent, Boolean> motionEventFunction) {
+        this.motionEventFunction = motionEventFunction;
+    }
 
     /**
      * Updates trainer preferences (e.g. learning strategies) if a faded setting has been changed.
@@ -259,7 +263,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         return true;
     }
 
-
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         boolean consumed = false;
@@ -274,6 +277,15 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         }
     }
 
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        boolean consumed = false;
+
+        if (motionEventFunction != null) consumed = motionEventFunction.apply(event);
+        if (!consumed) return super.dispatchTouchEvent(event);
+
+        return consumed;
+    }
 
     @Override
     public boolean onPreferenceStartFragment(PreferenceFragmentCompat caller, Preference pref) {
@@ -287,7 +299,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         setTitle(pref.getTitle());
         return true;
     }
-
 
     @Keep
     private static class SettingsChangeListener implements SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -255,6 +255,7 @@
     <string name="paddle_key_left">Linke Taste</string>
     <string name="paddle_key_right">Rechte Taste</string>
     <string name="record_paddle_key_code">Aufzeichnen</string>
+    <string name="recording_paddle_key_code">Zeichne auf…</string>
     <string name="record_paddle_prompt">Aufzuzeichnende Taste drücken</string>
     <string name="morse_input">Morse-Eingabe</string>
     <string name="morse_input_summary">Einstellungen für die Eingabe von Morse-Code</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,11 +277,12 @@
     <string name="prefs_summary_distribution_0">Each letter is as likely to occur as any other letter (uniformly distributed).</string>
     <string name="prefs_summary_distribution_x">Each letter is with a %1$d%% probability as likely to occur as in normal English words and with %2$d%% probability as likely as any other letter.</string>
     <string name="prefs_summary_distribution_10">Each letter is as likely to occur as it is in normal English words.</string>
-    <string name="keycodes_summary">Record key codes for your USB Morse key adapter</string>
-    <string name="keycodes">Record Key Codes</string>
+    <string name="keycodes_summary">Record key/button codes for your USB Morse key adapter</string>
+    <string name="keycodes">Record Key/Button Codes</string>
     <string name="paddle_key_left">Left paddle key</string>
     <string name="paddle_key_right">Right paddle key</string>
     <string name="record_paddle_key_code">Record</string>
+    <string name="recording_paddle_key_code">Recording…</string>
     <string name="record_paddle_prompt">Hit the key you want to record</string>
     <string name="morse_input">Morse input</string>
     <string name="morse_input_summary">Configure how you want to send Morse code</string>


### PR DESCRIPTION
This PR adds usb mouse functionality.

* Allows to listen to motion events in settings activity
* Saves the button state now in the button preference (one could argue that "key code" is not entirely accurate anymore and you might want to rename that)
* saves another key of the preference now that tells the app if the key code is to be interpreted as a motion event
* adjusts hardware sensor and paddle so that it can deal with motion events
* adjusts the activity in the sending part of the app so it calls the appropriate new event handler on the hardware paddle class

I noticed there is a leaking key/motion event listener: If you press "Record" and then navigate back the listener is still attached and will capture the next event. I couldn't find an easy way to fix this.

If this needs any adjustements, let me know. I tested it with an external keyboard (existing functionality) and with my USB morse adapter which emits mouse button clicks. It works fine :-)

Let me know if I can be of any other help here and since I haven't done Java in ages, let me know if anything needs adjustement.

One more thing: Instead of showing the key/button code I decided to show the constant name in the preferences. This makes the layout a little quirky, because it's longer than the number that was displayed there before. Maybe the layout can be tweaked here?